### PR TITLE
Fixed an error, if user does not configure anything on memcachedstats

### DIFF
--- a/pymunin/plugins/memcachedstats.py
+++ b/pymunin/plugins/memcachedstats.py
@@ -73,7 +73,7 @@ class MuninMemcachedPlugin(MuninPlugin):
         MuninPlugin.__init__(self, argv, env, debug)
         
         self._host = self.envGet('host')
-        self._port = self.envGet('port', None, int)
+        self._port = self.envGet('port', 11211, int)
         
         self._stats = None
         self._prev_stats = self.restoreState()


### PR DESCRIPTION
fixing 'TypeError: int() argument must be a string or a number, not 'NoneType'' error on memcached plugin
