### PR TITLE
Get rid of mutable default values for plugin constructors' parameters.

### DIFF
--- a/pymunin/__init__.py
+++ b/pymunin/__init__.py
@@ -37,7 +37,7 @@ class MuninAttrFilter:
     
     """
     
-    def __init__(self, list_include = [], list_exclude = [], 
+    def __init__(self, list_include = None, list_exclude = None,
                  attr_regex = None, default = True):
         """Initialize Munin Attribute Filter.
         
@@ -97,7 +97,7 @@ class MuninPlugin:
     """True for Multi-Graph Plugins, and False for Simple Plugins.
     Must be overriden in child classes to indicate plugin type."""
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Constructor for MuninPlugin Class.
         
         @param argv: List of command line arguments.
@@ -111,7 +111,7 @@ class MuninPlugin:
         self._filters = {}
         self._flags = {}
         self._argv = argv
-        self._env = env
+        self._env = env or {}
         self.arg0 = None
         self._debug = debug
         self._dirtyConfig = False

--- a/pymunin/plugins/apachestats.py
+++ b/pymunin/plugins/apachestats.py
@@ -58,7 +58,7 @@ class MuninApachePlugin(MuninPlugin):
     plugin_name = 'apachestats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -66,7 +66,7 @@ class MuninApachePlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self._host = self.envGet('host')
         self._port = self.envGet('port', None, int)

--- a/pymunin/plugins/asteriskstats.py
+++ b/pymunin/plugins/asteriskstats.py
@@ -84,7 +84,7 @@ class MuninAsteriskPlugin(MuninPlugin):
     plugin_name = 'asteriskstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -92,7 +92,7 @@ class MuninAsteriskPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
 
         self.envRegisterFilter('queues', '^[\w\-]+$')
         self._amihost = self.envGet('amihost')

--- a/pymunin/plugins/diskiostats.py
+++ b/pymunin/plugins/diskiostats.py
@@ -64,7 +64,7 @@ class MuninDiskIOplugin(MuninPlugin):
     plugin_name = 'diskiostats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -72,7 +72,7 @@ class MuninDiskIOplugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
 
         self._info = DiskIOinfo()
         

--- a/pymunin/plugins/diskusagestats.py
+++ b/pymunin/plugins/diskusagestats.py
@@ -61,7 +61,7 @@ class MuninDiskUsagePlugin(MuninPlugin):
     plugin_name = 'diskusagestats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -69,7 +69,7 @@ class MuninDiskUsagePlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self.envRegisterFilter('fspaths', '^[\w\-\/]+$')
         self.envRegisterFilter('fstypes', '^\w+$')

--- a/pymunin/plugins/fsstats.py
+++ b/pymunin/plugins/fsstats.py
@@ -54,7 +54,7 @@ class MuninFreeswitchPlugin(MuninPlugin):
     plugin_name = 'fsstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -62,7 +62,7 @@ class MuninFreeswitchPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
 
         self._fshost = self.envGet('fshost')
         self._fsport = self.envGet('fsport', None, int)

--- a/pymunin/plugins/lighttpdstats.py
+++ b/pymunin/plugins/lighttpdstats.py
@@ -58,7 +58,7 @@ class MuninLighttpdPlugin(MuninPlugin):
     plugin_name = 'lighttpdstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -66,7 +66,7 @@ class MuninLighttpdPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self._host = self.envGet('host')
         self._port = self.envGet('port', None, int)

--- a/pymunin/plugins/memcachedstats.py
+++ b/pymunin/plugins/memcachedstats.py
@@ -62,7 +62,7 @@ class MuninMemcachedPlugin(MuninPlugin):
     plugin_name = 'memcached'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -70,7 +70,7 @@ class MuninMemcachedPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self._host = self.envGet('host')
         self._port = self.envGet('port', None, int)

--- a/pymunin/plugins/mysqlstats.py
+++ b/pymunin/plugins/mysqlstats.py
@@ -78,7 +78,7 @@ class MuninMySQLplugin(MuninPlugin):
     plugin_name = 'pgstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -86,7 +86,7 @@ class MuninMySQLplugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self.envRegisterFilter('engine', '^\w+$')
         

--- a/pymunin/plugins/netifacestats.py
+++ b/pymunin/plugins/netifacestats.py
@@ -53,7 +53,7 @@ class MuninNetIfacePlugin(MuninPlugin):
     plugin_name = 'netifacestats'
     isMultigraph = True
     
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -61,7 +61,7 @@ class MuninNetIfacePlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
 
         self.envRegisterFilter('ifaces', '^[\w\d:]+$')
         

--- a/pymunin/plugins/netstats.py
+++ b/pymunin/plugins/netstats.py
@@ -55,7 +55,7 @@ class MuninNetstatsPlugin(MuninPlugin):
     plugin_name = 'netstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -63,7 +63,7 @@ class MuninNetstatsPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """     
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
          
         if self.graphEnabled('netstat_conn_status'):
             graph = MuninGraph('Network - Connection Status', 'Network', 

--- a/pymunin/plugins/nginxstats.py
+++ b/pymunin/plugins/nginxstats.py
@@ -68,7 +68,7 @@ class MuninNginxPlugin(MuninPlugin):
     plugin_name = 'nginxstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -76,7 +76,7 @@ class MuninNginxPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self._host = self.envGet('host')
         self._port = self.envGet('port', None, int)

--- a/pymunin/plugins/ntphostoffset_.py
+++ b/pymunin/plugins/ntphostoffset_.py
@@ -51,7 +51,7 @@ class MuninNTPhostOffsetPlugin(MuninPlugin):
     plugin_name = 'ntphostoffset_'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -59,7 +59,7 @@ class MuninNTPhostOffsetPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
 
         if self.arg0 is None:
             raise Exception("Remote host name cannot be determined.")

--- a/pymunin/plugins/ntphostoffsets.py
+++ b/pymunin/plugins/ntphostoffsets.py
@@ -55,7 +55,7 @@ class MuninNTPhostOffsetsPlugin(MuninPlugin):
     plugin_name = 'ntphostoffsets'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -63,7 +63,7 @@ class MuninNTPhostOffsetsPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
 
         if self.envHasKey('ntphosts'):
             hosts_str = re.sub('[^\d\.,]', '', self.envGet('ntphosts'))

--- a/pymunin/plugins/ntpstats.py
+++ b/pymunin/plugins/ntpstats.py
@@ -49,7 +49,7 @@ class MuninNTPstatsPlugin(MuninPlugin):
     plugin_name = 'ntpstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -57,7 +57,7 @@ class MuninNTPstatsPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """      
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
 
         if self.graphEnabled('ntp_peer_stratum'):
             graph = MuninGraph('NTP Stratum for System Peer', 'Time',

--- a/pymunin/plugins/pgstats.py
+++ b/pymunin/plugins/pgstats.py
@@ -88,7 +88,7 @@ class MuninPgPlugin(MuninPlugin):
     plugin_name = 'pgstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -96,7 +96,7 @@ class MuninPgPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self.envRegisterFilter('db', '^\w+$')
         self._host = self.envGet('host')

--- a/pymunin/plugins/phpapcstats.py
+++ b/pymunin/plugins/phpapcstats.py
@@ -62,7 +62,7 @@ class MuninPHPapcPlugin(MuninPlugin):
     plugin_name = 'phpapcstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -70,7 +70,7 @@ class MuninPHPapcPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self._host = self.envGet('host')
         self._port = self.envGet('port', None, int)

--- a/pymunin/plugins/phpfpmstats.py
+++ b/pymunin/plugins/phpfpmstats.py
@@ -58,7 +58,7 @@ class MuninPHPfpmPlugin(MuninPlugin):
     plugin_name = 'phpfpmstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -66,7 +66,7 @@ class MuninPHPfpmPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self._host = self.envGet('host')
         self._port = self.envGet('port', None, int)

--- a/pymunin/plugins/procstats.py
+++ b/pymunin/plugins/procstats.py
@@ -51,7 +51,7 @@ class MuninProcStatsPlugin(MuninPlugin):
     plugin_name = 'procstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -59,7 +59,7 @@ class MuninProcStatsPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """     
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
 
         for (prefix, title, desc) in (('proc', 'Processes', 'Number of processes'),
                                       ('thread', 'Threads', 'Number of threads')):

--- a/pymunin/plugins/sysstats.py
+++ b/pymunin/plugins/sysstats.py
@@ -57,7 +57,7 @@ class MuninSysStatsPlugin(MuninPlugin):
     plugin_name = 'sysstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -65,7 +65,7 @@ class MuninSysStatsPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """     
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self._sysinfo = SystemInfo()
         self._loadstats = None

--- a/pymunin/plugins/tomcatstats.py
+++ b/pymunin/plugins/tomcatstats.py
@@ -75,7 +75,7 @@ class MuninTomcatPlugin(MuninPlugin):
     plugin_name = 'tomcatstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -83,7 +83,7 @@ class MuninTomcatPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self.envRegisterFilter('ports', '^\d+$')
         

--- a/pymunin/plugins/varnishstats.py
+++ b/pymunin/plugins/varnishstats.py
@@ -55,7 +55,7 @@ class MuninVarnishPlugin(MuninPlugin):
     plugin_name = 'varnishstats'
     isMultigraph = True
 
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -63,7 +63,7 @@ class MuninVarnishPlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self._instance = self.envGet('instance')
         varnish_info = VarnishInfo(self._instance)

--- a/pymunin/plugins/wanpipestats.py
+++ b/pymunin/plugins/wanpipestats.py
@@ -56,7 +56,7 @@ class MuninWanpipePlugin(MuninPlugin):
     plugin_name = 'wanpipestats'
     isMultigraph = True
     
-    def __init__(self, argv=(), env={}, debug=False):
+    def __init__(self, argv=(), env=None, debug=False):
         """Populate Munin Plugin with MuninGraph instances.
         
         @param argv:  List of command line arguments.
@@ -64,7 +64,7 @@ class MuninWanpipePlugin(MuninPlugin):
         @param debug: Print debugging messages if True. (Default: False)
         
         """
-        MuninPlugin.__init__(self, argv, env, debug)
+        MuninPlugin.__init__(self, argv, env or {}, debug)
         
         self.envRegisterFilter('ifaces', '^[\w\d]+$')
 


### PR DESCRIPTION
Using mutable types as default values (e.g. `{}` or `[]`) can, in theory, screw up the next instantiation of that class. It is therefore better to avoid them.

Please find attached one possible solution.
