### PR TITLE
quick fix for varnishstat memory problem

### DIFF
--- a/pymunin/plugins/varnishstats.py
+++ b/pymunin/plugins/varnishstats.py
@@ -151,8 +151,8 @@ class MuninVarnishPlugin(MuninPlugin):
             for flabel, fname in (('header', 's_hdrbytes'), 
                                   ('body', 's_bodybytes'),):
                 finfo = self._desc.get(fname, '')
-                graph.addField(fname, flabel, draw='AREASTACK', type='DERIVE', 
-                           min=0, info=self._desc.get('s_hdrbytes'))
+                graph.addField(fname, flabel, draw='AREASTACK', type='COUNTER',
+                           min=0, info=self._desc.get(fname, ''))
             self.appendGraph(graph_name, graph)
 
         graph_name = 'varnish_workers'
@@ -184,9 +184,9 @@ class MuninVarnishPlugin(MuninPlugin):
             graph = MuninGraph('Varnish - Cache Memory Usage (bytes)', 
                 self._category,
                 info='Varnish cache memory usage in bytes.',
-                args='--base 1000 --lower-limit 0')
-            for flabel, fname in (('used', 'SMA.s0.g_bytes'), 
-                                  ('free', 'SMA.s0.g_space')):
+                args='--base 1024 --lower-limit 0')
+            for flabel, fname in (('used', 'SMA_s0_g_bytes'),
+                                  ('free', 'SMA_s0_g_space')):
                 finfo = self._desc.get(fname, '')
                 graph.addField(fname, flabel, draw='AREASTACK', type='GAUGE', 
                                min=0, info=finfo)
@@ -227,3 +227,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/pysysinfo/varnish.py
+++ b/pysysinfo/varnish.py
@@ -53,7 +53,7 @@ class VarnishInfo:
             mobj = re.match('(\S+)\s+(\d+)\s+(\d+\.\d+|\.)\s+(\S.*\S)\s*$', 
                             line)
             if mobj:
-                info_dict[mobj.group(1)] = util.parse_value(mobj.group(2))
+                info_dict[mobj.group(1).replace('.', '_')] = util.parse_value(mobj.group(2))
                 self._descDict[mobj.group(1)] = mobj.group(4)
         return info_dict
         return info_dict
@@ -78,3 +78,4 @@ class VarnishInfo:
         if len(self._descDict) == 0:
             self.getStats()
         return self._descDict.get(entry)
+


### PR DESCRIPTION
varnishstat Memory graph broken as it output the value in this form:
`multigraph varnish_memory
SMA.s0.g_bytes.value 1203772840
SMA.s0.g_space.value 473948760`

Which confuse munin's value parsing protocol.

I did a quick fix for this, but I believe it's far from perfect, simply hacky.
I find there's the autoFixname param in `MuninGraph`, but it's not working even if set, for the values got from `pysysinfo/vanish` are with dots, fixed names can no longer get value from the stat dict. 

I suggest to keep the fixName mechanism as simple as possible:  keep internal names so that they can be coordinated with each module, only fix them when output to munin protocol.

I'm not sure if this would break other plugins so I left the work for you, and it's ok if no one want's to touch that and keep this hacky patch ...  :)
