### PR TITLE
Allow connecting to MySQL via unix sockets

### DIFF
--- a/pysysinfo/mysql.py
+++ b/pysysinfo/mysql.py
@@ -39,11 +39,14 @@ class MySQLinfo:
         self._conn = None
         self._connParams = {}
         if host is not None:
-            self._connParams['host'] = host
-            if port is not None:
-                self._connParams['port'] = port
+            if host[:1] == "/":
+                self._connParams['unix_socket'] = host
             else:
-                self._connParams['port'] = defaultMySQLport
+                self._connParams['host'] = host
+                if port is not None:
+                    self._connParams['port'] = port
+                else:
+                    self._connParams['port'] = defaultMySQLport
         elif port is not None:
             self._connParams['host'] = '127.0.0.1'
             self._connParams['port'] = port


### PR DESCRIPTION
If the first character of the host name is '/' then use unix_socket instead of host. Mostly to allow connections to multiple instances on a system where there may or may not be network access (mysqld_multi for example), or where there are multiple instances to allow granting permissions to only localhost.
