### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Licensing
 _PyMunin_ is copyrighted free software made available under the terms of the 
 _GPL License Version 3_ or later.
 
-See the _COPYING_ file that acompanies the code for full licensing information.
+See the _COPYING_ file that accompanies the code for full licensing information.
 
 
 Download

--- a/pymunin/__init__.py
+++ b/pymunin/__init__.py
@@ -308,7 +308,7 @@ class MuninPlugin:
     def envHasKey(self, name):
         """Return True if environment variable with name exists.  
         
-        @param name: Name of environtment variable.
+        @param name: Name of environment variable.
         @return:     True if environment variable is defined.
         
         """
@@ -446,7 +446,7 @@ class MuninPlugin:
         return not self.isMultigraph or self.envCheckFilter('graphs', graph_name)
         
     def saveState(self,  stateObj):
-        """Utility methos to save plugin state stored in stateObj to persistent 
+        """Utility methods to save plugin state stored in stateObj to persistent 
         storage to permit access to previous state in subsequent plugin runs.
         
         Any object that can be pickled and unpickled can be used to store the 

--- a/pymunin/plugins/diskusagestats.py
+++ b/pymunin/plugins/diskusagestats.py
@@ -4,7 +4,7 @@ filesystems.
 
 Requirements
 
-  - Root user privileges may be requiered to access stats for filesystems 
+  - Root user privileges may be required to access stats for filesystems 
   without any read access for munin user.
 
 

--- a/pysysinfo/diskio.py
+++ b/pysysinfo/diskio.py
@@ -32,7 +32,7 @@ class DiskIOinfo:
     def __init__(self):
         """Initialization
         
-        @param autoInit: If True parse stats on initization.
+        @param autoInit: If True parse stats on initialization.
         
         """
         self._diskStats = None

--- a/pysysinfo/filesystem.py
+++ b/pysysinfo/filesystem.py
@@ -93,7 +93,7 @@ class FilesystemInfo:
     def getInodeUse(self):
         """Get disk space usage.
         
-        @return: Dictionary of filesysten inode utilization stats for filesystems.
+        @return: Dictionary of filesystem inode utilization stats for filesystems.
         
         """
         stats = {}

--- a/pysysinfo/netstat.py
+++ b/pysysinfo/netstat.py
@@ -45,8 +45,8 @@ class NetstatInfo:
                         resolve_users=True):
         """Execute netstat command and return result as a nested dictionary.
         
-        @param tcp:            Include TCP ports in ouput if True.
-        @param udp:            Include UDP ports in ouput if True.
+        @param tcp:            Include TCP ports in output if True.
+        @param udp:            Include UDP ports in output if True.
         @param ipv4:           Include IPv4 ports in output if True.
         @param ipv6:           Include IPv6 ports in output if True.
         @param include_listen: Include listening ports in output if True.
@@ -123,8 +123,8 @@ class NetstatInfo:
                  **kwargs):
         """Execute netstat command and return result as a nested dictionary.
         
-        @param tcp:            Include TCP ports in ouput if True.
-        @param udp:            Include UDP ports in ouput if True.
+        @param tcp:            Include TCP ports in output if True.
+        @param udp:            Include UDP ports in output if True.
         @param ipv4:           Include IPv4 ports in output if True.
         @param ipv6:           Include IPv6 ports in output if True.
         @param include_listen: Include listening ports in output if True.


### PR DESCRIPTION
There are small typos in:
- README.md
- pymunin/__init__.py
- pymunin/plugins/diskusagestats.py
- pysysinfo/diskio.py
- pysysinfo/filesystem.py
- pysysinfo/netstat.py

Fixes:
- Should read `output` rather than `ouput`.
- Should read `required` rather than `requiered`.
- Should read `methods` rather than `methos`.
- Should read `initialization` rather than `initization`.
- Should read `filesystem` rather than `filesysten`.
- Should read `environment` rather than `environtment`.
- Should read `accompanies` rather than `acompanies`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md