### PR TITLE
Changes for making PyMunin Python 3 compatible

### DIFF
--- a/pymunin/__init__.py
+++ b/pymunin/__init__.py
@@ -717,22 +717,22 @@ class MuninPlugin:
 
         """
         if self._host_name is not None:
-            print "host_name %s" % self._host_name
+            print("host_name %s" % self._host_name)
         for parent_name in self._graphNames:
             graph = self._graphDict[parent_name]
             if self.isMultigraph:
-                print "multigraph %s" % self._getMultigraphID(parent_name)
-            print self._formatConfig(graph.getConfig())
-            print
+                print("multigraph %s" % self._getMultigraphID(parent_name))
+            print(self._formatConfig(graph.getConfig()))
+            print()
         if (self.isMultigraph and self._nestedGraphs 
             and self._subgraphDict and self._subgraphNames):
             for (parent_name, subgraph_names) in self._subgraphNames.iteritems():
                 for graph_name in subgraph_names:
                     graph = self._subgraphDict[parent_name][graph_name]
-                    print "multigraph %s" % self.getMultigraphID(parent_name, 
-                                                                 graph_name)
-                    print self._formatConfig(graph.getConfig())
-                    print
+                    print("multigraph %s" % self.getMultigraphID(parent_name, 
+                                                                 graph_name))
+                    print(self._formatConfig(graph.getConfig()))
+                    print()
         return True
 
     def suggest(self):
@@ -754,18 +754,18 @@ class MuninPlugin:
         for parent_name in self._graphNames:
             graph = self._graphDict[parent_name]
             if self.isMultigraph:
-                print "multigraph %s" % self._getMultigraphID(parent_name)
-            print self._formatVals(graph.getVals())
-            print
+                print("multigraph %s" % self._getMultigraphID(parent_name))
+            print(self._formatVals(graph.getVals()))
+            print()
         if (self.isMultigraph and self._nestedGraphs 
             and self._subgraphDict and self._subgraphNames):
             for (parent_name, subgraph_names) in self._subgraphNames.iteritems():
                 for graph_name in subgraph_names:
                     graph = self._subgraphDict[parent_name][graph_name]
-                    print "multigraph %s" % self.getMultigraphID(parent_name, 
-                                                                 graph_name)
-                    print self._formatVals(graph.getVals())
-                    print
+                    print("multigraph %s" % self.getMultigraphID(parent_name, 
+                                                                 graph_name))
+                    print(self._formatVals(graph.getVals()))
+                    print()
         return True
 
     def run(self):
@@ -783,9 +783,9 @@ class MuninPlugin:
         elif oper == 'autoconf':
             ret = self.autoconf()
             if ret:
-                print "yes"
+                print("yes")
             else:
-                print "no"
+                print("no")
             ret = True
         elif oper == 'suggest':
             ret = self.suggest()
@@ -964,9 +964,9 @@ def muninMain(pluginClass, argv=None, env=None, debug=False):
         else:
             return 1
     except Exception:
-        print >> sys.stderr, "ERROR: %s" % repr(sys.exc_info()[1])
+        print("ERROR: %s" % repr(sys.exc_info()[1]), file=sys.stderr)
         if autoconf:
-            print "no"
+            print("no")
         if debug:
             raise
         else:

--- a/pymunin/__init__.py
+++ b/pymunin/__init__.py
@@ -9,7 +9,10 @@
 import os.path
 import sys
 import re
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 __author__ = "Ali Onur Uyar"
 __copyright__ = "Copyright 2011, Ali Onur Uyar"
@@ -717,21 +720,21 @@ class MuninPlugin:
 
         """
         if self._host_name is not None:
-            print "host_name %s" % self._host_name
+            print("host_name %s" % self._host_name)
         for parent_name in self._graphNames:
             graph = self._graphDict[parent_name]
             if self.isMultigraph:
-                print "multigraph %s" % self._getMultigraphID(parent_name)
-            print self._formatConfig(graph.getConfig())
+                print("multigraph %s" % self._getMultigraphID(parent_name))
+            print(self._formatConfig(graph.getConfig()))
             print
         if (self.isMultigraph and self._nestedGraphs 
             and self._subgraphDict and self._subgraphNames):
             for (parent_name, subgraph_names) in self._subgraphNames.iteritems():
                 for graph_name in subgraph_names:
                     graph = self._subgraphDict[parent_name][graph_name]
-                    print "multigraph %s" % self.getMultigraphID(parent_name, 
-                                                                 graph_name)
-                    print self._formatConfig(graph.getConfig())
+                    print("multigraph %s" % self.getMultigraphID(parent_name, 
+                                                                 graph_name))
+                    print(self._formatConfig(graph.getConfig()))
                     print
         return True
 
@@ -754,17 +757,17 @@ class MuninPlugin:
         for parent_name in self._graphNames:
             graph = self._graphDict[parent_name]
             if self.isMultigraph:
-                print "multigraph %s" % self._getMultigraphID(parent_name)
-            print self._formatVals(graph.getVals())
+                print("multigraph %s" % self._getMultigraphID(parent_name))
+            print(self._formatVals(graph.getVals()))
             print
         if (self.isMultigraph and self._nestedGraphs 
             and self._subgraphDict and self._subgraphNames):
             for (parent_name, subgraph_names) in self._subgraphNames.iteritems():
                 for graph_name in subgraph_names:
                     graph = self._subgraphDict[parent_name][graph_name]
-                    print "multigraph %s" % self.getMultigraphID(parent_name, 
-                                                                 graph_name)
-                    print self._formatVals(graph.getVals())
+                    print("multigraph %s" % self.getMultigraphID(parent_name, 
+                                                                 graph_name))
+                    print(self._formatVals(graph.getVals()))
                     print
         return True
 
@@ -783,9 +786,9 @@ class MuninPlugin:
         elif oper == 'autoconf':
             ret = self.autoconf()
             if ret:
-                print "yes"
+                print("yes")
             else:
-                print "no"
+                print("no")
             ret = True
         elif oper == 'suggest':
             ret = self.suggest()
@@ -966,7 +969,7 @@ def muninMain(pluginClass, argv=None, env=None, debug=False):
     except Exception:
         print >> sys.stderr, "ERROR: %s" % repr(sys.exc_info()[1])
         if autoconf:
-            print "no"
+            print("no")
         if debug:
             raise
         else:
@@ -1005,6 +1008,3 @@ def fixLabel(label, maxlen, delim=None, repl='', truncend=True):
             return label[:maxlen] + repl
         else:
             return repl + label[-maxlen:]
-            
-            
-    

--- a/pymunin/__init__.py
+++ b/pymunin/__init__.py
@@ -165,11 +165,11 @@ class MuninPlugin:
         """
         if not env:
             env = self._env
-        if env.has_key('MUNIN_STATEFILE'):
+        if 'MUNIN_STATEFILE' in env:
             self._stateFile = env.get('MUNIN_STATEFILE')
         else:
             self._stateFile = '/tmp/munin-state-%s' % self.plugin_name
-        if env.has_key('MUNIN_CAP_DIRTY_CONFIG'):
+        if 'MUNIN_CAP_DIRTY_CONFIG' in env:
             self._dirtyConfig = True
             
     def _getGraph(self, graph_name, fail_noexist=False):
@@ -199,7 +199,7 @@ class MuninPlugin:
         """
         if not self.isMultigraph:
             raise AttributeError("Simple Munin Plugins cannot have subgraphs.")
-        if self._graphDict.has_key(parent_name) is not None:
+        if (parent_name in self._graphDict) is not None:
             subgraphs = self._subgraphDict.get(parent_name)
             if subgraphs is not None:
                 subgraph = subgraphs.get(graph_name)
@@ -316,7 +316,7 @@ class MuninPlugin:
         @return:     True if environment variable is defined.
         
         """
-        return self._env.has_key(name)
+        return name in self._env
     
     def envGet(self, name, default=None, conv=None):
         """Return value for environment variable or None.  
@@ -327,7 +327,7 @@ class MuninPlugin:
         @return:        Value of environment variable.
         
         """
-        if self._env.has_key(name):
+        if name in self._env:
             if conv is not None:
                 return conv(self._env.get(name))
             else:
@@ -352,7 +352,7 @@ class MuninPlugin:
         """
         key = "list_%s" % name
         item_list = []
-        if self._env.has_key(key):
+        if key in self._env:
             if attr_regex:
                 recomp = re.compile(attr_regex)
             else:
@@ -416,7 +416,7 @@ class MuninPlugin:
         @return:        Return True if the flag is enabled.
         
         """
-        if self._flags.has_key(name):
+        if name in self._flags:
             return self._flags[name]
         else:
             val = self._env.get(name)
@@ -512,8 +512,8 @@ class MuninPlugin:
         """
         if not self.isMultigraph:
             raise AttributeError("Simple Munin Plugins cannot have subgraphs.")
-        if self._graphDict.has_key(parent_name):
-            if not self._subgraphDict.has_key(parent_name):
+        if parent_name in self._graphDict:
+            if parent_name not in self._subgraphDict:
                 self._subgraphDict[parent_name] = {}
                 self._subgraphNames[parent_name] = []
             self._subgraphDict[parent_name][graph_name] = graph
@@ -566,7 +566,7 @@ class MuninPlugin:
         @return:           Boolean
         
         """
-        return self._graphDict.has_key(graph_name)
+        return graph_name in self._graphDict
     
     def hasSubgraph(self, parent_name, graph_name):
         """Return true if Root Graph with name parent_name has a subgraph with 
@@ -604,7 +604,7 @@ class MuninPlugin:
         """
         if not self.isMultigraph:
             raise AttributeError("Simple Munin Plugins cannot have subgraphs.")
-        if self._graphDict.has_key(parent_name):
+        if parent_name in self._graphDict:
             return self._subgraphNames[parent_name] or []
         else:
             raise AttributeError("Invalid parent graph name %s."
@@ -729,7 +729,7 @@ class MuninPlugin:
             print()
         if (self.isMultigraph and self._nestedGraphs 
             and self._subgraphDict and self._subgraphNames):
-            for (parent_name, subgraph_names) in self._subgraphNames.iteritems():
+            for (parent_name, subgraph_names) in self._subgraphNames.items():
                 for graph_name in subgraph_names:
                     graph = self._subgraphDict[parent_name][graph_name]
                     print("multigraph %s" % self.getMultigraphID(parent_name, 
@@ -762,7 +762,7 @@ class MuninPlugin:
             print()
         if (self.isMultigraph and self._nestedGraphs 
             and self._subgraphDict and self._subgraphNames):
-            for (parent_name, subgraph_names) in self._subgraphNames.iteritems():
+            for (parent_name, subgraph_names) in self._subgraphNames.items():
                 for graph_name in subgraph_names:
                     graph = self._subgraphDict[parent_name][graph_name]
                     print("multigraph %s" % self.getMultigraphID(parent_name, 
@@ -831,7 +831,7 @@ class MuninGraph:
                              by replacing them with '_'.
         
         """
-        self._graphAttrDict = dict((k,v) for (k,v) in locals().iteritems()
+        self._graphAttrDict = dict((k,v) for (k,v) in locals().items()
                                     if (v is not None 
                                         and k not in ('self', 'autoFixNames')))
         self._fieldNameList = []
@@ -869,7 +869,7 @@ class MuninGraph:
             name = self._fixName(name)
             if negative is not None:
                 negative = self._fixName(negative)
-        self._fieldAttrDict[name] = dict(((k,v) for (k,v) in locals().iteritems()
+        self._fieldAttrDict[name] = dict(((k,v) for (k,v) in locals().items()
                                          if (v is not None
                                              and k not in ('self',))))
         self._fieldNameList.append(name)
@@ -883,7 +883,7 @@ class MuninGraph:
         """
         if self._autoFixNames:
             name = self._fixName(name)
-        return self._fieldAttrDict.has_key(name)
+        return name in self._fieldAttrDict
     
     def getFieldList(self):
         """Returns list of field names registered to Munin Graph.
@@ -954,7 +954,7 @@ def muninMain(pluginClass, argv=None, env=None, debug=False):
         argv = sys.argv
     if env is None:
         env = os.environ
-    debug = debug or env.has_key('MUNIN_DEBUG')
+    debug = debug or 'MUNIN_DEBUG' in env
     if len(argv) > 1 and argv[1] == 'autoconf':
         autoconf = True
     else:
@@ -967,7 +967,7 @@ def muninMain(pluginClass, argv=None, env=None, debug=False):
         else:
             return 1
     except Exception:
-        print("ERROR: %s" % repr(sys.exc_info()[1]), file=sys.stderr)
+        print("ERROR: %s" % repr(sys.exc_info()[1]), sys.stderr)
         if autoconf:
             print("no")
         if debug:

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class install(_install):
         _install.run(self)
         # Installing the plugins requires write permission to plugins directory
         # (/usr/share/munin/plugins) which is default owned by root.
-        print "Munin Plugin Directory: %s" % munin_plugin_dir
+        print("Munin Plugin Directory: %s" % munin_plugin_dir)
         if os.path.exists(munin_plugin_dir):
             try:
                 for name in plugin_names:
@@ -71,18 +71,18 @@ class install(_install):
                         u'%s-%s' % (PYMUNIN_SCRIPT_FILENAME_PREFIX, name)
                     )
                     destination = os.path.join(munin_plugin_dir, name)
-                    print "Installing %s to %s." % (name, munin_plugin_dir)
+                    print("Installing %s to %s." % (name, munin_plugin_dir))
                     shutil.copy(source, destination)
-            except IOError, e:
+            except IOError as e:
                 if e.errno in  (errno.EACCES, errno.ENOENT):
                     # Access denied or file/directory not found.
-                    print "*" * 78
+                    print("*" * 78)
                     if e.errno == errno.EACCES:
-                        print ("You do not have permission to install the plugins to %s." 
-                               % munin_plugin_dir)
+                        print("You do not have permission to install the plugins to %s." 
+                              % munin_plugin_dir)
                     if e.errno == errno.ENOENT:
-                        print ("Failed installing the plugins to %s. "
-                               "File or directory not found." % munin_plugin_dir)
+                        print("Failed installing the plugins to %s. "
+                              "File or directory not found." % munin_plugin_dir)
                     script = os.path.join(self.install_scripts, 'pymunin-install')
                     f = open(script, 'w')
                     try:
@@ -96,11 +96,11 @@ class install(_install):
                             f.write('cp %s %s\n' % (source, destination))
                     finally:
                         f.close()
-                    os.chmod(script, 0755)
-                    print ("You will need to copy manually using the script: %s\n"
-                           "Example: sudo %s"
+                    os.chmod(script, 0o755)
+                    print("You will need to copy manually using the script: %s\n"
+                          "Example: sudo %s"
                            % (script, script))
-                    print "*" * 78
+                    print("*" * 78)
                 else:
                     # Raise original exception
                     raise

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class install(_install):
         _install.run(self)
         # Installing the plugins requires write permission to plugins directory
         # (/usr/share/munin/plugins) which is default owned by root.
-        print "Munin Plugin Directory: %s" % munin_plugin_dir
+        print("Munin Plugin Directory: %s" % munin_plugin_dir)
         if os.path.exists(munin_plugin_dir):
             try:
                 for name in plugin_names:
@@ -71,12 +71,12 @@ class install(_install):
                         u'%s-%s' % (PYMUNIN_SCRIPT_FILENAME_PREFIX, name)
                     )
                     destination = os.path.join(munin_plugin_dir, name)
-                    print "Installing %s to %s." % (name, munin_plugin_dir)
+                    print("Installing %s to %s." % (name, munin_plugin_dir))
                     shutil.copy(source, destination)
-            except IOError, e:
+            except(IOError, e):
                 if e.errno in  (errno.EACCES, errno.ENOENT):
                     # Access denied or file/directory not found.
-                    print "*" * 78
+                    print("*" * 78)
                     if e.errno == errno.EACCES:
                         print ("You do not have permission to install the plugins to %s." 
                                % munin_plugin_dir)
@@ -96,11 +96,11 @@ class install(_install):
                             f.write('cp %s %s\n' % (source, destination))
                     finally:
                         f.close()
-                    os.chmod(script, 0755)
+                    os.chmod(script, 0o755)
                     print ("You will need to copy manually using the script: %s\n"
                            "Example: sudo %s"
                            % (script, script))
-                    print "*" * 78
+                    print("*" * 78)
                 else:
                     # Raise original exception
                     raise

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ class install(_install):
     "Extend base install class to provide a post-install step."
 
     def run(self):
-        if os.environ.has_key('MUNIN_PLUGIN_DIR'):
+        if 'MUNIN_PLUGIN_DIR' in os.environ:
             munin_plugin_dir = os.environ.get('MUNIN_PLUGIN_DIR')
         elif self.root is None:
             munin_plugin_dir = os.path.normpath(


### PR DESCRIPTION
I'm in the process of writing an nftables plugin for Munin and came across PyMunin. Installing it through pip failed due to Pyhton 2 syntax in `setup.py` and `pymunin/__ini__.py`.

With this PR the module should install in a Python 3 environment.

I installed it locally from the repository root using:

```
pip install --user -e .
```

I did not check any of the plugins for Python 3 compatibility.
